### PR TITLE
Load ADMIN_ID from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+BOT_TOKEN=your-telegram-bot-token
+OPENAI_API_KEY=your-openai-api-key
+ADMIN_ID=your-telegram-id

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# FreeBeeBPT Bot
+
+A Telegram bot using aiogram and OpenAI for sports predictions.
+
+## Configuration
+
+Create a `.env` file based on `.env.example` and provide:
+
+- `BOT_TOKEN` – Telegram bot token
+- `OPENAI_API_KEY` – your OpenAI API key
+- `ADMIN_ID` – Telegram ID to receive registration notifications
+
+Install dependencies with `pip install -r requirements.txt` and run the bot with `python bot.py`.

--- a/bot.py
+++ b/bot.py
@@ -10,13 +10,12 @@ from openai import AsyncOpenAI
 load_dotenv()
 BOT_TOKEN = os.getenv("BOT_TOKEN")
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+# ID администратора для уведомлений
+ADMIN_ID = int(os.getenv("ADMIN_ID"))
 
 bot = Bot(token=BOT_TOKEN)
 dp = Dispatcher(bot)
 client = AsyncOpenAI(api_key=OPENAI_API_KEY)
-
-# ID администратора для уведомлений
-ADMIN_ID = 200082134
 
 # Хранилище уже зарегистрированных пользователей
 registered_users: set[int] = set()


### PR DESCRIPTION
## Summary
- allow configuring ADMIN_ID in environment variables
- provide a `.env.example`
- document env vars in README

## Testing
- `python -m py_compile bot.py`


------
https://chatgpt.com/codex/tasks/task_e_686d0a22a8908321945efd727cfcbff1