### PR TITLE
Add Docker ignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,24 @@
+# Exclude Git repository
+.git/
+
+# Python cache
+__pycache__/
+*.py[cod]
+
+# Virtual environments
+venv/
+env/
+.venv/
+
+# Build artifacts
+build/
+dist/
+*.egg-info/
+
+# Logs and databases
+*.log
+*.sqlite3
+*.db
+
+# Misc
+.DS_Store


### PR DESCRIPTION
## Summary
- ignore `.git/`, `__pycache__/`, `*.pyc`, and other build artifacts during Docker builds

## Testing
- `docker build -t freebeebpt-test .` *(fails: `docker` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d0b470a388321bb3e57370f474d9a