### PR TITLE
Add /start_fal and /stop_fal admin commands to toggle FAL image generation

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -105,7 +105,7 @@ register_admin_news_handlers(
 async def start_handler(message: types.Message):
     await message.answer(
         "Привет! Это спортивный новостной бот.\n"
-        "Доступные админ-команды: /news_status, /fetch_news_now, /fetch_topic, /test_channel, /news_test, /news_test_ai, /news_test_image, /news_test_full, /news_test_preview, /news_debug_last, /last_preview_status, /news_test_raw, /news_test_compare, /new_state, /cancel"
+        "Доступные админ-команды: /news_status, /start_fal, /stop_fal, /fetch_news_now, /fetch_topic, /test_channel, /news_test, /news_test_ai, /news_test_image, /news_test_full, /news_test_preview, /news_debug_last, /last_preview_status, /news_test_raw, /news_test_compare, /new_state, /cancel"
     )
 
 

--- a/handlers/admin_news.py
+++ b/handlers/admin_news.py
@@ -42,6 +42,7 @@ def register_admin_news_handlers(dp: Dispatcher, *, context: dict[str, Any]) -> 
                 [
                     f"mode: {news_post_mode}",
                     f"api key configured: {'yes' if gnews_service.configured else 'no'}",
+                    f"fal_generation_enabled: {'yes' if news_pipeline.is_fal_generation_enabled() else 'no'}",
                     f"today_requests: {repository.get_daily_requests()}",
                     f"last_fetch_time: {stats['last_fetch_time'] or 'never'}",
                     f"last_topic: {stats['last_topic'] or 'n/a'}",
@@ -52,6 +53,20 @@ def register_admin_news_handlers(dp: Dispatcher, *, context: dict[str, Any]) -> 
                 ]
             )
         )
+
+    @dp.message_handler(commands=["start_fal"])
+    async def start_fal_handler(message: types.Message):
+        if not await _ensure_admin(message):
+            return
+        news_pipeline.set_fal_generation_enabled(True)
+        await message.answer("✅ Генерация изображений включена (/start_fal)")
+
+    @dp.message_handler(commands=["stop_fal"])
+    async def stop_fal_handler(message: types.Message):
+        if not await _ensure_admin(message):
+            return
+        news_pipeline.set_fal_generation_enabled(False)
+        await message.answer("⏸ Генерация изображений отключена (/stop_fal). Новости продолжат публиковаться без картинок.")
 
     @dp.message_handler(commands=["new_state"])
     async def new_state_handler(message: types.Message, state: FSMContext):

--- a/services/news_pipeline.py
+++ b/services/news_pipeline.py
@@ -49,9 +49,16 @@ class NewsPipeline:
         self.extract_timeout = int(os.getenv("ARTICLE_EXTRACT_TIMEOUT", "15"))
         self.article_min_text_length = int(os.getenv("ARTICLE_MIN_TEXT_LENGTH", "800"))
         self.manual_review_required = os.getenv("NEWS_MANUAL_REVIEW_REQUIRED", "true").lower() == "true"
+        self.fal_generation_enabled = os.getenv("FAL_GENERATION_ENABLED", "true").lower() == "true"
 
     def _is_admin_review_mode(self) -> bool:
         return self.news_post_mode == "admin"
+
+    def set_fal_generation_enabled(self, enabled: bool) -> None:
+        self.fal_generation_enabled = enabled
+
+    def is_fal_generation_enabled(self) -> bool:
+        return self.fal_generation_enabled
 
     async def _prepare_article(self, article: dict[str, Any]) -> dict[str, Any]:
         extraction = {"success": False, "text": None, "error": None, "method": "none"}
@@ -105,6 +112,14 @@ class NewsPipeline:
         return fallback_prompt
 
     async def _generate_image(self, article: dict[str, Any], ai_result: AINewsResult) -> dict[str, Any]:
+        if not self.fal_generation_enabled:
+            logger.info("[FAL] skipped manually by /stop_fal article_hash=%s", article.get("article_hash"))
+            return {
+                "request_id": None,
+                "image_url": None,
+                "fal_status": "disabled_by_admin",
+                "fal_error": "fal generation disabled by admin command",
+            }
         prompt = self._ensure_image_prompt(article, ai_result)
         if not prompt:
             return {"request_id": None, "image_url": None, "fal_status": "skipped", "fal_error": "image_prompt_en is empty"}


### PR DESCRIPTION
### Motivation
- Allow the administrator to enable or disable automatic FAL image generation at runtime without stopping the news flow. 
- Keep publishing of news active even when image generation is turned off so previews/posts continue to be delivered without images.

### Description
- Added admin commands ` /start_fal` and `/stop_fal` in `handlers/admin_news.py` which call `news_pipeline.set_fal_generation_enabled(True|False)` and reply with a confirmation message. 
- Exposed the current flag in the `/news_status` output via `fal_generation_enabled: yes/no` for quick visibility. 
- Added `fal_generation_enabled` state (defaulted from `FAL_GENERATION_ENABLED`) and runtime methods `set_fal_generation_enabled()` and `is_fal_generation_enabled()` to `NewsPipeline`, and short-circuited `_generate_image()` to return a disabled status when generation is turned off. 
- Updated the `/start` help text in `bot.py` to list the new admin commands.

### Testing
- Ran `pytest -q` in the environment which attempted to collect tests but failed during import with `ModuleNotFoundError: No module named 'aiogram'`, so unit tests could not complete here. 
- No other automated tests were executed in this environment; the new behavior is implemented behind the `NewsPipeline` toggle and guarded by admin checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c23ed1077c83219dc57a50a0eb84be)